### PR TITLE
Fix the serp-sdk package to use serpapi

### DIFF
--- a/src/serp/serp.service.spec.ts
+++ b/src/serp/serp.service.spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SerpService } from './serp.service';
-import { SerpClient } from 'serp-sdk';
+import { SerpApi } from 'serpapi';
 
-jest.mock('serp-sdk');
+jest.mock('serpapi');
 
 describe('SerpService', () => {
   let service: SerpService;
-  let serpClientMock: jest.Mocked<SerpClient>;
+  let serpApiMock: jest.Mocked<SerpApi>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -14,7 +14,7 @@ describe('SerpService', () => {
     }).compile();
 
     service = module.get<SerpService>(SerpService);
-    serpClientMock = SerpClient as jest.Mocked<typeof SerpClient>;
+    serpApiMock = SerpApi as jest.Mocked<typeof SerpApi>;
   });
 
   it('should be defined', () => {
@@ -22,27 +22,27 @@ describe('SerpService', () => {
   });
 
   describe('searchGoogle', () => {
-    it('should call SerpClient.search with Google engine', async () => {
+    it('should call SerpApi.json with Google engine', async () => {
       const query = 'test query';
       const searchResult = { data: 'some data' };
-      serpClientMock.prototype.search.mockResolvedValue(searchResult);
+      serpApiMock.prototype.json.mockResolvedValue(searchResult);
 
       const result = await service.searchGoogle(query);
 
-      expect(serpClientMock.prototype.search).toHaveBeenCalledWith(query, { engine: 'google' });
+      expect(serpApiMock.prototype.json).toHaveBeenCalledWith(query, { engine: 'google' });
       expect(result).toEqual(searchResult);
     });
   });
 
   describe('searchDuckDuckGo', () => {
-    it('should call SerpClient.search with DuckDuckGo engine', async () => {
+    it('should call SerpApi.json with DuckDuckGo engine', async () => {
       const query = 'test query';
       const searchResult = { data: 'some data' };
-      serpClientMock.prototype.search.mockResolvedValue(searchResult);
+      serpApiMock.prototype.json.mockResolvedValue(searchResult);
 
       const result = await service.searchDuckDuckGo(query);
 
-      expect(serpClientMock.prototype.search).toHaveBeenCalledWith(query, { engine: 'duckduckgo' });
+      expect(serpApiMock.prototype.json).toHaveBeenCalledWith(query, { engine: 'duckduckgo' });
       expect(result).toEqual(searchResult);
     });
   });

--- a/src/serp/serp.service.ts
+++ b/src/serp/serp.service.ts
@@ -1,25 +1,25 @@
 import { Injectable } from '@nestjs/common';
-import { SerpClient } from 'serp-sdk';
+import { SerpApi } from 'serpapi';
 import { ConfigService } from '../config/config.service';
 
 @Injectable()
 export class SerpService {
-  private readonly serpClient: SerpClient;
+  private readonly serpApi: SerpApi;
 
   constructor(private readonly configService: ConfigService) {
     const apiKey = this.configService.get('SERP_API_KEY');
-    this.serpClient = new SerpClient(apiKey);
+    this.serpApi = new SerpApi(apiKey);
   }
 
   async search(query: string): Promise<any> {
-    return this.serpClient.search(query);
+    return this.serpApi.json(query);
   }
 
   async searchGoogle(query: string): Promise<any> {
-    return this.serpClient.search(query, { engine: 'google' });
+    return this.serpApi.json(query, { engine: 'google' });
   }
 
   async searchDuckDuckGo(query: string): Promise<any> {
-    return this.serpClient.search(query, { engine: 'duckduckgo' });
+    return this.serpApi.json(query, { engine: 'duckduckgo' });
   }
 }


### PR DESCRIPTION
Replace the `serp-sdk` package with the `serpapi` package in `src/serp/serp.service.ts` and `src/serp/serp.service.spec.ts`.

* **src/serp/serp.service.ts**
  - Replace the import of `SerpClient` from `serp-sdk` with `SerpApi` from `serpapi`.
  - Update the constructor to initialize `SerpApi` with the API key.
  - Update the `search`, `searchGoogle`, and `searchDuckDuckGo` methods to use `SerpApi`.

* **src/serp/serp.service.spec.ts**
  - Replace the import of `SerpClient` from `serp-sdk` with `SerpApi` from `serpapi`.
  - Update the mock implementation to use `SerpApi`.
  - Update the tests to match the new `SerpApi` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sylvestre67/gh-workspace/pull/5?shareId=6a07dfb7-290c-487a-b131-d86040889b7e).