### PR TITLE
Add search endpoints for Google and DuckDuckGo

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^11.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
-    "serpapi": "^2.1.0"
+    "serpapi": "^2.1.0",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,22 +1,53 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { HttpService, HttpModule } from '@nestjs/axios';
+import { SerpService } from './serp/serp.service';
 
 describe('AppController', () => {
   let appController: AppController;
+  let serpService: SerpService;
 
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
       controllers: [AppController],
-      providers: [AppService],
+      providers: [AppService, SerpService, HttpService],
     }).compile();
 
     appController = app.get<AppController>(AppController);
+    serpService = app.get<SerpService>(SerpService);
   });
 
   describe('root', () => {
     it('should return "Hello World!"', () => {
       expect(appController.getHello()).toBe('Hello World!');
+    });
+  });
+
+  describe('searchGoogle', () => {
+    it('should return search results from Google', async () => {
+      const query = 'test query';
+      const searchResult = { data: 'some data' };
+      jest.spyOn(serpService, 'searchGoogle').mockResolvedValue(searchResult);
+
+      const result = await appController.searchGoogle(query);
+
+      expect(result).toEqual(searchResult);
+      expect(serpService.searchGoogle).toHaveBeenCalledWith(query);
+    });
+  });
+
+  describe('searchDuckDuckGo', () => {
+    it('should return search results from DuckDuckGo', async () => {
+      const query = 'test query';
+      const searchResult = { data: 'some data' };
+      jest.spyOn(serpService, 'searchDuckDuckGo').mockResolvedValue(searchResult);
+
+      const result = await appController.searchDuckDuckGo(query);
+
+      expect(result).toEqual(searchResult);
+      expect(serpService.searchDuckDuckGo).toHaveBeenCalledWith(query);
     });
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,32 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AppService } from './app.service';
+import { SerpService } from './serp/serp.service';
 
+@ApiTags('Search')
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    private readonly serpService: SerpService,
+  ) {}
 
   @Get()
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @Get('search/google')
+  @ApiOperation({ summary: 'Perform a Google search' })
+  @ApiResponse({ status: 200, description: 'Search results' })
+  async searchGoogle(@Query('query') query: string): Promise<any> {
+    return this.serpService.searchGoogle(query);
+  }
+
+  @Get('search/duckduckgo')
+  @ApiOperation({ summary: 'Perform a DuckDuckGo search' })
+  @ApiResponse({ status: 200, description: 'Search results' })
+  async searchDuckDuckGo(@Query('query') query: string): Promise<any> {
+    return this.serpService.searchDuckDuckGo(query);
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,10 +3,11 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { SerpModule } from './serp/serp.module';
 import { ConfigModule } from './config/config.module';
+import { SerpService } from './serp/serp.service';
 
 @Module({
   imports: [SerpModule, ConfigModule],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, SerpService],
 })
 export class AppModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { setupSwagger } from './swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  setupSwagger(app);
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,0 +1,13 @@
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { INestApplication } from '@nestjs/common';
+
+export function setupSwagger(app: INestApplication): void {
+  const options = new DocumentBuilder()
+    .setTitle('API Documentation')
+    .setDescription('API description')
+    .setVersion('1.0')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, options);
+  SwaggerModule.setup('api', app, document);
+}


### PR DESCRIPTION
Add endpoints for Google and DuckDuckGo search functionality and set up Swagger documentation.

* Add `@nestjs/swagger` and `swagger-ui-express` dependencies in `package.json`.
* Create `src/swagger.ts` to configure Swagger documentation.
* Modify `src/main.ts` to set up Swagger in the `bootstrap` function.
* Add `SerpService` to `AppController` in `src/app.controller.ts` and create endpoints for Google and DuckDuckGo search.
* Add tests for the new search endpoints in `src/app.controller.spec.ts`.
* Add `SerpService` to the `providers` array in `src/app.module.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sylvestre67/gh-workspace/pull/7?shareId=dd777b7c-dd1d-4631-90b6-9e2ed60ce1c9).