### PR TITLE
Fix ConfigService dependency resolution in AppModule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,11 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { SerpModule } from './serp/serp.module';
 import { ConfigModule } from './config/config.module';
-import { SerpService } from './serp/serp.service';
 
 @Module({
   imports: [SerpModule, ConfigModule],
   controllers: [AppController],
-  providers: [AppService, SerpService],
+  providers: [AppService],
 })
 export class AppModule {}

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule as NestConfigModule } from '@nestjs/config';
+import { ConfigService } from './config.service';
 
 @Module({
   imports: [NestConfigModule.forRoot()],
-  exports: [NestConfigModule],
+  providers: [ConfigService],
+  exports: [NestConfigModule, ConfigService],
 })
 export class ConfigModule {}


### PR DESCRIPTION
Resolve `ConfigService` dependency in `AppModule` context for `SerpService`.

* **ConfigModule**: Add `ConfigService` to the `providers` and `exports` arrays in `src/config/config.module.ts`.
* **AppModule**: Remove `SerpService` from the `providers` array in `src/app.module.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sylvestre67/gh-workspace/pull/8?shareId=69a4b87f-b14a-4188-8972-514132695e78).